### PR TITLE
chore: fix PyPI version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Apache 2.0 License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![API Reference](https://img.shields.io/badge/API-Reference-blue)](https://galirage.github.io/spreadsheet-intelligence/)
-[![PyPI version](https://img.shields.io/pypi/v/your-package-name.svg)](https://pypi.org/project/spreadsheet-intelligence/)
+[![PyPI version](https://img.shields.io/pypi/v/spreadsheet-intelligence.svg)](https://pypi.org/project/spreadsheet-intelligence/)
 
 ## ⚡ Quick Install
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
This PR fixes the PyPI version badge URL in the README.md file by replacing the placeholder "your-package-name" with the actual package name "spreadsheet-intelligence".

## Motivation and Context
The PyPI version badge was displaying an incorrect link with a placeholder value. This change ensures the badge correctly links to the actual spreadsheet-intelligence package on PyPI, improving the documentation accuracy.

## Related Issues
N/A - Minor documentation fix

## How has this been tested?
- Verified the badge URL now correctly points to https://pypi.org/project/spreadsheet-intelligence/
- Confirmed the badge displays properly in the README preview

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Branch Strategy
**Target branch:** main
**Source branch type:** 
- [ ] feature/* (merge to develop branch)
- [ ] hotfix/* (merge to develop and main branches)
- [x] develop (merge to main branch)
- [ ] release/* (merge to develop and main branches)
- [ ] Other: ___________

## Checklist:
- [x] I have followed the git-flow branching strategy for target branch selection
- [x] If merging to main, this PR is from develop or release/* branch
- [x] My code follows the project's coding standards
- [x] I have updated documentation/tests if required